### PR TITLE
add model as setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You can download the plugin from the JetBrains MarketPlace - [Docgen](https://pl
 Features
 --------
 
-*   Generate code documentation using OpenAI's `gpt-3.5-turbo` model
+*   Generate code documentation using OpenAI's models
 *   Option to use a custom prompt
 
 Installation
@@ -35,6 +35,12 @@ Usage
 3.  Wait for the OpenAI model to generate the documentation
 4.  The generated documentation will be displayed in a popup window
 5.  Click `Insert` to add the documentation to your Python function
+
+Model
+-----
+
+The default model is `gpt-3.5-turbo`. To use another model go to `Preferences > Tools > Docgen` and
+enter the model name in the provided input field.
 
 Prompt
 ------

--- a/src/main/java/com/profiq/codexor/SettingsConfigurable.java
+++ b/src/main/java/com/profiq/codexor/SettingsConfigurable.java
@@ -13,18 +13,28 @@ import java.awt.*;
 
 public class SettingsConfigurable implements Configurable {
     public static String API_KEY_SETTING_KEY = "codexor.apiKey";
+    public static String MODEL_SETTINGS_KEY = "codexor.model";
+    public static String MODEL_DEFAULT = "gpt-3.5-turbo";
     public static String PROMPT_SETTINGS_KEY = "codexor.prompt";
     public static String PROMPT_DEFAULT = "Generate high-quality docstring for the following Python function including function signature: ";
 
     private final JTextField apiKeyField;
+    private final JTextField modelField;
     private final JTextArea promptField;
     private final JPanel ui;
     private String currentApiKey;
+    private String currentModel;
     private String currentPrompt;
 
     public SettingsConfigurable() {
         currentApiKey = PropertiesComponent.getInstance().getValue(API_KEY_SETTING_KEY);
+        currentModel = PropertiesComponent.getInstance().getValue(MODEL_SETTINGS_KEY);
         currentPrompt = PropertiesComponent.getInstance().getValue(PROMPT_SETTINGS_KEY);
+
+        if(currentModel == null) {
+            currentModel = MODEL_DEFAULT;
+            PropertiesComponent.getInstance().setValue(MODEL_SETTINGS_KEY, currentModel);
+        }
 
         if(currentPrompt == null) {
             currentPrompt = PROMPT_DEFAULT;
@@ -41,6 +51,14 @@ public class SettingsConfigurable implements Configurable {
         apiKeyField.setSize(250, 30);
         apiKeyField.setPreferredSize(new Dimension(600, 30));
         apiKeyField.setToolTipText("You can get your API key from https://openai.com/");
+
+        var modelLabel = new JLabel();
+        modelLabel.setText("Model: ");
+        modelLabel.setPreferredSize(labelDimension);
+        modelField = new JBTextField();
+        modelField.setText(currentModel);
+        modelField.setSize(250, 30);
+        modelField.setPreferredSize(new Dimension(600, 30));
 
 
         var promptLabel = new JLabel();
@@ -69,12 +87,19 @@ public class SettingsConfigurable implements Configurable {
 
         c.gridx = 0;
         c.gridy = 1;
+        ui.add(modelLabel, c);
+
+        c.gridx = 1;
+        ui.add(modelField, c);
+
+        c.gridx = 0;
+        c.gridy = 2;
         ui.add(promptLabel, c);
 
         c.gridx = 1;
         ui.add(promptField, c);
 
-        c.gridy = 2;
+        c.gridy = 3;
         var filler = new JLabel();
         filler.setPreferredSize(new Dimension(0, 200));
         ui.add(filler, c);
@@ -92,24 +117,32 @@ public class SettingsConfigurable implements Configurable {
 
     @Override
     public boolean isModified() {
-        return !apiKeyField.getText().equals(currentApiKey) || !promptField.getText().equals(currentPrompt);
+        return !apiKeyField.getText().equals(currentApiKey)
+            || !promptField.getText().equals(currentPrompt)
+            || !modelField.getText().equals(currentModel);
     }
 
     @Override
     public void apply() {
         currentApiKey = apiKeyField.getText();
+        currentModel = modelField.getText();
         currentPrompt = promptField.getText();
 
         if (currentApiKey.length() == 0)
             currentApiKey = null;
 
+        if (currentModel.length() == 0)
+            currentModel = null;
+
         PropertiesComponent.getInstance().setValue(API_KEY_SETTING_KEY, currentApiKey);
+        PropertiesComponent.getInstance().setValue(MODEL_SETTINGS_KEY, currentModel);
         PropertiesComponent.getInstance().setValue(PROMPT_SETTINGS_KEY, currentPrompt);
     }
 
     @Override
     public void reset() {
         apiKeyField.setText(currentApiKey);
+        modelField.setText(currentModel);
         promptField.setText(currentPrompt);
     }
 }


### PR DESCRIPTION
I added "model" to the plugin's settings. The default value remained as `gpt-3.5-turbo` but now we can change model to the `gpt-4` and others.

It looks like this now:
![image](https://github.com/profiq/docgen/assets/51539577/87f2875b-9b5c-4a06-a9e7-4ad6a07de15b)
