### PR TITLE
Implement better support for documenting classes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.profiq"
-version = "0.1.3"
+version = "0.1.4"
 
 repositories {
     mavenCentral()
@@ -19,7 +19,7 @@ dependencies {
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
     version.set("2023.3")
-    type.set("IC") // Target IDE Platform
+    type.set("PC") // Target IDE Platform
 
     plugins.set(listOf(/* Plugin Dependencies */))
 }

--- a/src/main/java/com/profiq/codexor/GenerateDocumentationAction.java
+++ b/src/main/java/com/profiq/codexor/GenerateDocumentationAction.java
@@ -112,8 +112,6 @@ public class GenerateDocumentationAction extends AnAction {
     }
 
     private static HttpRequest buildRequest(String apiKey, String model, String prompt, String code) {
-        System.out.println(prompt);
-
         var messages = new Message[]{new Message("user", prompt + "```" + code + "```")};
         var requestBody = new Request(model, messages, 0);
         var requestJson = new Gson().toJson(requestBody);

--- a/src/main/java/com/profiq/codexor/GenerateDocumentationAction.java
+++ b/src/main/java/com/profiq/codexor/GenerateDocumentationAction.java
@@ -56,7 +56,7 @@ public class GenerateDocumentationAction extends AnAction {
         PsiElement element = e.getData(CommonDataKeys.PSI_ELEMENT);
 
         if (element == null) {
-            showError("Please select a Python function");
+            showError("Please select a Python function, method or class");
             return;
         }
 
@@ -112,6 +112,8 @@ public class GenerateDocumentationAction extends AnAction {
     }
 
     private static HttpRequest buildRequest(String apiKey, String model, String prompt, String code) {
+        System.out.println(prompt);
+
         var messages = new Message[]{new Message("user", prompt + "```" + code + "```")};
         var requestBody = new Request(model, messages, 0);
         var requestJson = new Gson().toJson(requestBody);
@@ -127,7 +129,10 @@ public class GenerateDocumentationAction extends AnAction {
         Pattern pattern = Pattern.compile(":\n(\\s*\"\"\".*\"\"\")", Pattern.DOTALL);
         Matcher matcher = pattern.matcher(responseText);
         if (matcher.find()) {
-            return matcher.group(1);
+            String docstring = matcher.group(1);
+            String[] docstringSplit = docstring.split("\"\"\"");
+            docstring = docstringSplit[0] + "\"\"\"" + docstringSplit[1] + "\"\"\"";
+            return docstring;
         } else {
             return "";
         }
@@ -187,7 +192,6 @@ public class GenerateDocumentationAction extends AnAction {
         editor.getContentComponent().setPreferredSize(new Dimension(1000, 800));
         var confirmBtn = new JButton("Insert");
 
-
         Editor mainEditor = e.getData(CommonDataKeys.EDITOR);
         Document mainDocument = mainEditor.getDocument();
         LogicalPosition caretPosition = mainEditor.getCaretModel().getLogicalPosition();
@@ -225,6 +229,7 @@ public class GenerateDocumentationAction extends AnAction {
 
             for (String line : lines) {
                 unindented.append(indentation);
+
                 if (line.length() >= minIndent) {
                     unindented.append(line.substring(minIndent));
                 }
@@ -242,7 +247,7 @@ public class GenerateDocumentationAction extends AnAction {
         Matcher matcher = pattern.matcher(code);
 
         if(matcher.find()) {
-            return matcher.group(1);
+            return matcher.group(1).replace("\n", "");
         }
 
         return "";

--- a/src/main/java/com/profiq/codexor/SettingsConfigurable.java
+++ b/src/main/java/com/profiq/codexor/SettingsConfigurable.java
@@ -16,7 +16,7 @@ public class SettingsConfigurable implements Configurable {
     public static String MODEL_SETTINGS_KEY = "codexor.model";
     public static String MODEL_DEFAULT = "gpt-3.5-turbo";
     public static String PROMPT_SETTINGS_KEY = "codexor.prompt";
-    public static String PROMPT_DEFAULT = "Generate high-quality docstring for the following Python function including function signature: ";
+    public static String PROMPT_DEFAULT = "Generate high-quality docstring for the following Python class or function.  Use the reStructuredText docstring format. Only return the docstring for the top-level element:";
 
     private final JTextField apiKeyField;
     private final JTextField modelField;


### PR DESCRIPTION
This PR improves the support for class docstrings. It includes the following changes:

- New default prompt explicitly specifying docstring format and mentioning that the input can be both a class or a function.
- Better GPT output sanitation
- Better determination of correct indentation

It also changes the default IDE for testing to PyCharm.